### PR TITLE
Incorrect Order of Variables in CHANNEL.dat Parser

### DIFF
--- a/SASpy.py
+++ b/SASpy.py
@@ -252,7 +252,7 @@ def readChannel(dat):
 
     channel_keys = [
         'zFuel',  'zClad',  'zCool',  'zStruct','FeJ',    'TcoolA', 'Tclad',  'Tfuel',
-        'Tcool',  'Tsat',   'fMelt',  'CmidT',  'Cmelt',  'Tstruct','Wout',   'Win',
+        'Tsat',   'fMelt',  'CmidT',  'Cmelt',  'Tcool', 'Tstruct', 'Wout',   'Win',
         'Tout',   'Tin'
     ]
     for key in channel_keys:


### PR DESCRIPTION
Fixing an error in the order of the channel dependent variables in CHANNEL.dat. `Tcool` was in the wrong location. The next version of the SAS manual (5.8) can be used to confirm this.